### PR TITLE
Minor corrections in the quick start guide.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -135,7 +135,7 @@ npm install --save @lottiefiles/lottie-interactivity</pre
             Add Lottie component to your html dom.
           </div>
           <pre class="prettyprint mb-6" style="overflow: scroll;">
-&#x3C;lottie-player id=&#x22;firstLottie&#x22; src=&#x22;https://assets2.lottiefiles.com/packages/lf20_i9mxcD.json&#x22; style=&#x22;width:400px; height: 400px;&#x22;&#x3E;&#x22;&#x3E;&#x3C;/lottie-player&#x3E;</pre
+&#x3C;lottie-player id=&#x22;firstLottie&#x22; src=&#x22;https://assets2.lottiefiles.com/packages/lf20_i9mxcD.json&#x22; style=&#x22;width:400px; height: 400px;&#x22;&#x3E;&#x3C;/lottie-player&#x3E;</pre
           >
           <div class="font-bold font-lf-bold leading-lf text-xl my-4">
             Configure library


### PR DESCRIPTION
Updated `index.html` : 

Removed additional Unicode Hex Characters: `#x22` and `#x3E`

Note: GitHub's markdown is not allowing me to paste the exact character code; the code mentioned above, correspond to doublequotes (") and  greater-than (>) symbol.

Note: I'm assuming to accommodate this correction properly, there is a need to fix the backend services as well. Specifically, the service used for displaying dynamic URLs in the start guide, when users are directed from lottiefiles.com

I'll be happy to contribute.