### PR TITLE
fix(scroll): with 'scroll' mode and type as 'play' plays animation once and pauses at end

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,6 +43,7 @@ export class LottieInteractivity {
     this.actions = actions;
     this.options = options;
     this.assignedSegment = null;
+    this.scrolledAndPlayed = false;
   }
 
   getContainerVisibility() {
@@ -69,7 +70,6 @@ export class LottieInteractivity {
     // Configure player for start
     if (this.mode === 'scroll') {
       this.player.addEventListener('DOMLoaded', function () {
-        Parentscope.player.loop = true;
         Parentscope.player.stop();
         window.addEventListener('scroll', Parentscope.#scrollHandler);
       });
@@ -203,6 +203,7 @@ export class LottieInteractivity {
         true,
       );
     } else if (action.type === 'loop') {
+      this.player.loop = true;
       // Loop: Loop a given frames
       if (this.assignedSegment === null) {
         // if not playing any segments currently. play those segments and save to state
@@ -225,8 +226,9 @@ export class LottieInteractivity {
       }
     } else if (action.type === 'play') {
       // Play: Reset segments and continue playing full animation from current position
-      if (this.player.isPaused === true) {
-        this.player.resetSegments();
+      if (!this.scrolledAndPlayed) {
+        this.scrolledAndPlayed = true;
+        this.player.resetSegments(true);
         this.player.play();
       }
     } else if (action.type === 'stop') {


### PR DESCRIPTION
## Description

With 'scroll' mode and 'play' type lottie-interactivity will now play the animation when visible and pause at end. If playing an animation on scroll and having it loop is needed, 'loop' type can be used.

Related [issue](https://github.com/LottieFiles/lottie-interactivity/issues/17)

## Type of change

- [x] Lottie-Interactivty Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.

## Notes

Impact of removing pause check and playing animation directly ? 
