### PR TITLE
Prevent scroll-seeking from going past the end

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,7 @@ export class LottieInteractivity {
       this.player.goToAndStop(
         Math.ceil(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *
-            this.player.totalFrames,
+            (this.player.totalFrames - 1),
         ),
         true,
       );


### PR DESCRIPTION
## Description

Currently, if you use `seek` with the end of your `visibility` parameter < 1 to finish animation before the end of the viewport, lottie-interactivity will attempt to seek beyond the end of the animation, resulting in a blank frame.

Since the frame number you use when seeking is zero-indexed but the totalFrames count from Lottie is not, we just need to subtract 1 from the total frame count to seek to the final frame.

I have a reproducible test case at https://codepen.io/mccahan/pen/QWvzKBO or using the following HTML, where scrolling until the heart is about to disappear off the top of the screen you'll see it flash and disappear instead of stopping at the final frame.

```html
<html>
<head>
  <script src='https://unpkg.com/@lottiefiles/lottie-player@0.4.0/dist/lottie-player.js'></script>
  <script src='dist/lottie-interactivity.min.js'></script>
  <style>
    #thirdLottie {
      max-width: 300px;
      height: auto;
      margin: 80vh auto;
    }

    body {
      min-height: 200vh;
    }
  </style>
</head>
<body>
  <lottie-player id="thirdLottie" src="https://assets6.lottiefiles.com/packages/lf20_QpeChC.json" background="transparent"></lottie-player>
  <script>
    LottieInteractivity.create({
      mode: "scroll",
      player: "#thirdLottie",
      actions: [
        {
          visibility: [0, 0.3],
          type: "stop",
          frames: [0]
        },
        {
          visibility: [0.3, 0.9],
          type: "seek",
          frames: [0, 301]
        }
      ]
    });
  </script>
</body>
</html>
```

https://user-images.githubusercontent.com/2308923/128763454-45ecdbb9-b932-470f-9f1a-0ec94487f7b4.mp4

