### PR TITLE
Fix missing/misplaced commas in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -337,7 +337,7 @@ LottieInteractivity.create({
                 player: "#fourthLottie",
                   actions: [
                     {
-                      visibility:[0, 0.2,]
+                      visibility:[0, 0.2],
                       type: "stop",
                       frames: [0]
                     },
@@ -385,7 +385,7 @@ LottieInteractivity.create({
             player: "#fifthLottie",
               actions: [
                 {
-                  visibility:[0, 1]
+                  visibility:[0, 1],
                   type: "loop",
                   frames: [70, 500]
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,7 @@ export class LottieInteractivity {
       this.player.goToAndStop(
         Math.ceil(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *
-            this.player.totalFrames,
+            (this.player.totalFrames - 1),
         ),
         true,
       );


### PR DESCRIPTION
## Description

One missing and one misplaced comma in the `examples/index.html` documentation file.