### PR TITLE
Fix a missing and misplaced comma in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -337,7 +337,7 @@ LottieInteractivity.create({
                 player: "#fourthLottie",
                   actions: [
                     {
-                      visibility:[0, 0.2,]
+                      visibility:[0, 0.2],
                       type: "stop",
                       frames: [0]
                     },
@@ -385,7 +385,7 @@ LottieInteractivity.create({
             player: "#fifthLottie",
               actions: [
                 {
-                  visibility:[0, 1]
+                  visibility:[0, 1],
                   type: "loop",
                   frames: [70, 500]
                 }


### PR DESCRIPTION
## Description

Fix one missing and one misplaced comma in the example code in `examples/index.html`