### PR TITLE
Use start/end frames specified by user when scroll-seeking

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -198,6 +198,14 @@ export class LottieInteractivity {
       const start = action.frames[0];
       const end = action.frames.length == 2 ? action.frames[1] : (this.player.totalFrames - 1);
 
+      // Use global frame reference for frames within the seek section.
+      // Without this, if you follow a seek with a loop and then scroll back up,
+      // it will treat frame numbers as relative to the loop.
+      if (this.assignedSegment !== null) {
+        this.player.resetSegments(true);
+        this.assignedSegment = null;
+      }
+
       this.player.goToAndStop(
         start + Math.round(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *

--- a/src/main.js
+++ b/src/main.js
@@ -195,10 +195,13 @@ export class LottieInteractivity {
     // Process action types:
     if (action.type === 'seek') {
       // Seek: Go to a frame based on player scroll position action
+      const start = action.frames[0];
+      const end = action.frames.length == 2 ? action.frames[1] : (this.player.totalFrames - 1);
+
       this.player.goToAndStop(
-        Math.ceil(
+        start + Math.round(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *
-            this.player.totalFrames,
+            (end - start)
         ),
         true,
       );


### PR DESCRIPTION
## Description

The documentation states that you can use your own start/end frames during a seek action on scroll (e.g. https://github.com/LottieFiles/lottie-interactivity/blob/master/examples/index.js#L77), but the existing code always uses from 0 to the final frame of the Lottie animation. This PR adjusts that so that it respects the frames passed by the user as a start/end of the seek action.

I believe this follows more in line with the documentation, and fixes an issue on the robot demo where seeks from the start to the end (including showing his legs) and then pops back to an earlier frame to show the loop instead of only showing the first 45 frames and then looping: https://lottiefiles.com/interactivity#fourth

# Reversing behavior / seek-and-loop

I'm not sure whether this is a bug or not, but with the existing code, if you go from a seek into a loop on scroll, when you scroll back up again all of the goToAndStop()s for the seek will now be relative to the loop you just ran. With the robot demo, it works out fine in that when scrolling from top to bottom he flies in and then loops his hover animation, and when you scroll back up he just continues looping his hover, but I'm not sure whether that's working as intended or if it just lucks out here that it works.

With my change, it always uses the global frame count for seeking, which I think is the expected behavior, but changes the robot demo so that he flies out of the screen when you scroll back up again. I suspect there may be a benefit to having an additional option to pass in that would change that behavior, but I figured that wasn't my decision to make. I also don't know how many users out there are relying on this "unexpected" behavior.

Here's the robot behavior with line 201-207 of `src/main.js` in place:

https://user-images.githubusercontent.com/2308923/128772205-850e5cfb-25ba-423a-92c2-d68115c48157.mp4

# Round vs Ceil

NOTE: I thought a bit about it and changed this to using `Math.round()` instead of `Math.ceil()` because otherwise unless you have a very large scroll viewport it's nigh-impossible to actually get the first frame with ceil. I'm not married to that particular piece, and leave that up to you all. I included it in this PR because I considered it part of the bug with not respecting user start/end frames because it was basically impossible to reach the start frame. The current code goes from first frame to last frame inclusively, so round() felt like the right move.