### PR TITLE
Start and end frame seeking / scroll fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -198,6 +198,14 @@ export class LottieInteractivity {
       const start = action.frames[0];
       const end = action.frames.length == 2 ? action.frames[1] : (this.player.totalFrames - 1);
 
+      // Use global frame reference for frames within the seek section.
+      // Without this, if you follow a seek with a loop and then scroll back up,
+      // it will treat frame numbers as relative to the loop.
+      if (this.assignedSegment !== null) {
+        this.player.resetSegments(true);
+        this.assignedSegment = null;
+      }
+
       this.player.goToAndStop(
         start + Math.round(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *

--- a/src/main.js
+++ b/src/main.js
@@ -195,10 +195,13 @@ export class LottieInteractivity {
     // Process action types:
     if (action.type === 'seek') {
       // Seek: Go to a frame based on player scroll position action
+      const start = action.frames[0];
+      const end = action.frames.length == 2 ? action.frames[1] : (this.player.totalFrames - 1);
+
       this.player.goToAndStop(
-        Math.ceil(
+        start + Math.round(
           ((currentPercent - action.visibility[0]) / (action.visibility[1] - action.visibility[0])) *
-            this.player.totalFrames,
+            (end - start)
         ),
         true,
       );


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

Fixes issues #30 and #33 relating to scroll-seeking not using entered values and prevent going past the last frame.

## Type of change

- [x] lottie-interactivity Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
