### PR TITLE
When cursor hovers svg element of animation no longer stops loop

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -114,7 +114,11 @@ export class LottieInteractivity {
           Parentscope.player.loop = true;
           Parentscope.player.stop();
           Parentscope.container.addEventListener('mousemove', Parentscope.#mousemoveHandler);
-          Parentscope.container.addEventListener('mouseout', Parentscope.#mouseoutHandler);
+          Parentscope.container.addEventListener('mouseleave', Parentscope.#mouseoutHandler);
+
+          // Init the animations that set states when the cursor is outside the container, so that they
+          // are visibly idle at the desired frame before first interaction with them
+          Parentscope.#cursorHandler(-1, -1);
         }
       });
     } else if (this.mode === 'chain') {
@@ -201,7 +205,7 @@ export class LottieInteractivity {
         this.container.removeEventListener('click', this.#clickHoverHandler);
         this.container.removeEventListener('mouseenter', this.#clickHoverHandler);
         this.container.removeEventListener('mousemove', this.#mousemoveHandler);
-        this.container.removeEventListener('mouseout', this.#mouseoutHandler);
+        this.container.removeEventListener('mouseleave', this.#mouseoutHandler);
     }
 
     if (this.mode === 'chain') {
@@ -727,6 +731,7 @@ export class LottieInteractivity {
       }
       this.player.playSegments(action.frames);
     } else if (action.type === 'stop') {
+      this.player.resetSegments(true);
       // Stop: Stop playback
       this.player.goToAndStop(action.frames[0], true);
     }


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

When the cursor hovered over an actual svg element of the animation, the mouseout event was fired, stopping the animation. This fix changes the listened event to 'mouseleave' so that the animation only stops when the cursor is moved outside the container. 

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] Lottie-Interactivity Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
