### PR TITLE
fix(scrolling): fixed segments not playing on scroll with 'play' action type

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -867,7 +867,11 @@ export class LottieInteractivity {
       if (!this.scrolledAndPlayed) {
         this.scrolledAndPlayed = true;
         this.player.resetSegments(true);
-        this.player.play();
+        if (action.frames) {
+          this.player.playSegments(action.frames, true);
+        } else {
+          this.player.play();
+        }
       }
     } else if (action.type === 'stop') {
       // Stop: Stop playback


### PR DESCRIPTION
## Description

fixed segments not playing on scroll with 'play' action type

## Type of change

- [x] lottie-interactivity Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
