### PR TITLE
fix: changed way window is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lottiefiles/lottie-interactivity",
   "description": "This is a small effects and interactivity library written to be paired with the Lottie Web Player",
-  "version": "1.3.4-beta.1",
+  "version": "1.3.5",
   "license": "MIT",
   "main": "./dist/lottie-interactivity.min.js",
   "module": "./dist/lottie-interactivity.es.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lottiefiles/lottie-interactivity",
   "description": "This is a small effects and interactivity library written to be paired with the Lottie Web Player",
-  "version": "1.3.4-beta.0",
+  "version": "1.3.4-beta.1",
   "license": "MIT",
   "main": "./dist/lottie-interactivity.min.js",
   "module": "./dist/lottie-interactivity.es.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lottiefiles/lottie-interactivity",
   "description": "This is a small effects and interactivity library written to be paired with the Lottie Web Player",
-  "version": "0.1.5",
+  "version": "1.3.4-beta.0",
   "license": "MIT",
   "main": "./dist/lottie-interactivity.min.js",
   "module": "./dist/lottie-interactivity.es.js",

--- a/src/main.js
+++ b/src/main.js
@@ -58,6 +58,9 @@ export class LottieInteractivity {
     this.playCounter = 0;
     this.stateHandler = new Map();
     this.transitionHandler = new Map();
+
+    //globals
+    this.window = this.container.ownerDocument.defaultView;
   }
 
   getContainerVisibility() {
@@ -65,8 +68,8 @@ export class LottieInteractivity {
     const { top, height } = this.container.getBoundingClientRect();
 
     // Calculate current view percentage
-    const current = window.innerHeight - top;
-    const max = window.innerHeight + height;
+    const current = this.window.innerHeight - top;
+    const max = this.window.innerHeight + height;
     return current / max;
   }
 
@@ -81,7 +84,7 @@ export class LottieInteractivity {
 
   initScrollMode() {
     this.player.stop();
-    window.addEventListener('scroll', this.#scrollHandler);
+    this.window.addEventListener('scroll', this.#scrollHandler);
   }
 
   initCursorMode() {
@@ -227,7 +230,7 @@ export class LottieInteractivity {
 
   stop() {
     if (this.mode === 'scroll') {
-      window.removeEventListener('scroll', this.#scrollHandler);
+      this.window.removeEventListener('scroll', this.#scrollHandler);
     }
 
     if (this.mode === 'cursor') {
@@ -670,14 +673,14 @@ export class LottieInteractivity {
         throw new Error(`${ERROR_PREFIX} Specified player is invalid.`, this.enteredPlayer);
       }
     } else {
-      if (window.lottie) {
+      if (this.window.lottie) {
         this.stop();
         this.player.destroy();
         // Removes svg animation contained inside
         this.container.innerHTML = "";
 
         if (typeof path === 'object' && path.constructor.name === 'AnimationItem') {
-          this.player = window.lottie.loadAnimation({
+          this.player = this.window.lottie.loadAnimation({
             loop: false,
             autoplay: false,
             animationData: path.animationData,
@@ -685,7 +688,7 @@ export class LottieInteractivity {
           });
         }
         else {
-          this.player = window.lottie.loadAnimation({
+          this.player = this.window.lottie.loadAnimation({
             loop: false,
             autoplay: false,
             path,

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,7 @@ export class LottieInteractivity {
 
   initScrollMode() {
     this.player.stop();
-    this.window.addEventListener('scroll', this.#scrollHandler);
+    this.window.addEventListener('scroll', this.#scrollHandler, true);
   }
 
   initCursorMode() {
@@ -230,7 +230,7 @@ export class LottieInteractivity {
 
   stop() {
     if (this.mode === 'scroll') {
-      this.window.removeEventListener('scroll', this.#scrollHandler);
+      this.window.removeEventListener('scroll', this.#scrollHandler, true);
     }
 
     if (this.mode === 'cursor') {


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

Fix for issue #58 scroll event not firing within iframes

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->
Rather than using the global window, its fetched from ownerDocument and defaultView

- [x] lottie-interactivity Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
