### PR TITLE
fix: fixed error when player is destroyed and redefineOptions is called

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -173,7 +173,6 @@ export class LottieInteractivity {
 
   redefineOptions({actions, container, mode, player, ...options}) {
     this.stop();
-    this.player.stop();
 
     // Save the original player entered by user, used for interaction chaining / loading animations on the fly
     this.enteredPlayer = player;
@@ -262,11 +261,19 @@ export class LottieInteractivity {
       this.container.removeEventListener('mouseout', this.#mouseoutHandler);
       this.container.removeEventListener('touchend', this.#holdTransitionLeave);
 
-      this.player.removeEventListener('loopComplete', this.#onCompleteHandler);
-      this.player.removeEventListener('complete', this.#onCompleteHandler);
-      this.player.removeEventListener('enterFrame', this.#cursorSyncHandler);
-      this.player.removeEventListener('enterFrame', this.#holdTransitionHandler);
+      if (this.player) {
+        try {
+          this.player.removeEventListener('loopComplete', this.#onCompleteHandler);
+          this.player.removeEventListener('complete', this.#onCompleteHandler);
+          this.player.removeEventListener('enterFrame', this.#cursorSyncHandler);
+          this.player.removeEventListener('enterFrame', this.#holdTransitionHandler);    
+        } catch(e) {
+          // User deleted the player before calling stop()
+          // Ignore
+        }
+      }
     }
+    this.player = null;
   }
 
   /**


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->
Fixed null error when player is destroyed and redefineOptions is called.
Fix for #63 

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] lottie-interactivity Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] This is something we need to do.
