### PR TITLE
fix: fixed autoplay not being removed after onComplete transition

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -751,6 +751,7 @@ export class LottieInteractivity {
    * as any extra options
    */
   #chainedInteractionHandler = ({ ignorePath }) => {
+    let frames = this.actions[this.interactionIdx].frames;
     let state = this.actions[this.interactionIdx].state;
     let transition = this.actions[this.interactionIdx].transition;
     let path = this.actions[this.interactionIdx].path;
@@ -766,6 +767,11 @@ export class LottieInteractivity {
       return;
     }
     setTimeout(() => {
+      if (frames) {
+        this.player.autoplay = false;
+        this.player.resetSegments(true);
+        this.player.goToAndStop(frames[0], true);
+      }
       if (stateFunction) {
         stateFunction.call();
       } else if (state === "none") {

--- a/tests/public/manual-interaction.html
+++ b/tests/public/manual-interaction.html
@@ -103,7 +103,7 @@
                     transition: 'onComplete',
                     frames: [130, 491],
                 }, {
-                    state: 'hold',
+                    state: 'pauseHold',
                     transition: 'pauseHold',
                     frames: [491, 612]
                 },


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->
Fixed autoplay not being removed after onComplete transition.

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] lottie-interactivity Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
