### PR TITLE
Fix: destroy call on null player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.1
+
+### Patch Changes
+
+- fixed stop error, added playOnce to scroll
+
 ## 1.6.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lottiefiles/lottie-interactivity",
   "description": "This is a small effects and interactivity library written to be paired with the Lottie Web Player",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "main": "./dist/lottie-interactivity.min.js",
   "module": "./dist/lottie-interactivity.es.js",

--- a/src/main.js
+++ b/src/main.js
@@ -272,7 +272,10 @@ export class LottieInteractivity {
         }
       }
     }
-    this.player = null;
+    if (this.player) {
+      this.player.destroy();
+      this.player = null;
+    }
   }
 
   /**
@@ -742,7 +745,6 @@ export class LottieInteractivity {
     } else {
       if (window.lottie) {
         this.stop();
-        this.player.destroy();
         // Removes svg animation contained inside
         this.container.innerHTML = "";
 
@@ -938,10 +940,18 @@ export class LottieInteractivity {
           }
         }
       }
-    } else if (action.type === 'play') {
+    } else if (action.type === 'play' || action.type === 'playOnce') {
       // Play: Reset segments and continue playing full animation from current position
-      if (!this.scrolledAndPlayed) {
+      if (action.type === 'playOnce' && !this.scrolledAndPlayed) {
         this.scrolledAndPlayed = true;
+        this.player.resetSegments(true);
+        if (action.frames) {
+          this.player.playSegments(action.frames, true);
+        } else {
+          this.player.play();
+        }
+        return;
+      } else if (action.type === 'play' && this.player.isPaused) {
         this.player.resetSegments(true);
         if (action.frames) {
           this.player.playSegments(action.frames, true);

--- a/tests/public/index.html
+++ b/tests/public/index.html
@@ -446,7 +446,7 @@
       <div class="w-full md:w-1/2 mx-auto">
         <pre class="prettyprint lang-javascript" style="overflow: scroll;">
         LottieInteractivity.create({
-          mode:"cursor",
+          mode:"scroll",
           player:'#twelfthLottie',
           actions: [{
             visibility: [0.50, 1.0],
@@ -474,7 +474,7 @@
       <div class="w-full md:w-1/2 mx-auto">
         <pre class="prettyprint lang-javascript" style="overflow: scroll;">
         LottieInteractivity.create({
-          mode:"cursor",
+          mode:"scroll",
           player:'#twelfthLottie',
           actions: [{
             visibility: [0.50, 1.0],


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

- Fixed a destroy call happening whilst the player was null.
- Added 'playOnce' for the scroll type

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
