### PR TITLE
fix: initialize scroll position

### DIFF
--- a/.changeset/tame-comics-smile.md
+++ b/.changeset/tame-comics-smile.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/lottie-interactivity': patch
+---
+
+initialize scroll position restored on page reload

--- a/src/lottie-interactivity.js
+++ b/src/lottie-interactivity.js
@@ -82,6 +82,7 @@ export class LottieInteractivity {
 
   initScrollMode() {
     this.player.stop();
+    this.#scrollHandler();
     window.addEventListener('scroll', this.#scrollHandler, true);
   }
 


### PR DESCRIPTION
When the browser restores the scroll position on page reload, it doesn't fire a scroll event, so the scroll handler needs to be called separately after the `DOMContentLoaded` event.
